### PR TITLE
Use APP_HOST env for origin header

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -35,7 +35,11 @@ export default defineNuxtModule<ModuleOptions>({
 
     // Get the version of the woonuxt-settings plugin
     try {
-      const { data } = await $fetch(GQL_HOST, { method: 'POST', body: JSON.stringify({ query: getVersionQuery }) });
+      const { data } = await $fetch(GQL_HOST, {
+        method: 'POST',
+        body: JSON.stringify({ query: getVersionQuery }),
+        headers: { 'Origin': process.env.APP_HOST || 'http://localhost:3000' }
+      });
       const stringVersion = data.woonuxtSettings?.wooCommerceSettingsVersion.replace(/\D/g, '');
       WOONUXT_SETTINGS_PLUGIN_VERSION = parseFloat(stringVersion);
       if (WOONUXT_SETTINGS_PLUGIN_VERSION < LATEST_VERSION) {


### PR DESCRIPTION
This pull request is similar to [PR #266](https://github.com/scottyzen/woonuxt/pull/266) on the Woonuxt repository. It introduces the APP_HOST environment variable to ensure that requests include the correct Origin header, which is essential for domain authorization. 
Additionally, this PR enables the application to successfully read the settings and retrieve the version of the woonuxt-settings plugin when unauthorized domains are blocked.